### PR TITLE
Streamline date checks / creation

### DIFF
--- a/t/basic.t
+++ b/t/basic.t
@@ -9,16 +9,12 @@ my $date = 2023-01-13;
 
 is $date, Date.new(2023,1,13), "Friday the 13th";
 
-try {
-    my $bad = 2023-01-99;
+{
+    "use Slang::Date; 2023-01-99".EVAL;
     CATCH {
-       when  X::OutOfRange {
-           ok True, "Invalid date caught";
-           exit;
-       }
-       default {
-           nok "Invalid date wrong error";
-       }
+       is .message, 'Day out of range. Is: 99, should be in 1..31',
+         'invalid date caught';
+       exit
     }
 }
-nok "Invalid date not caught";
+flunk "Invalid date not caught";


### PR DESCRIPTION
- revert to using a single token, it's all that's needed
- use Str.Date functionality rather than Date.new(YYYY,MM,DD)
- check date at compile time, panic at the right location if failed
- generate QAST for a Date constant, rather than creating at run-time
- adjust tests accordingly