### PR TITLE
Add dependency on Slangify + add RakuAST support

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -6,6 +6,7 @@
   "build-depends": [
   ],
   "depends": [
+    "Slangify:ver<0.0.1+>:auth<zef:lizmat>"
   ],
   "description": "Slang adding date literals to source",
   "license": "Artistic-2.0",

--- a/lib/Slang/Date.rakumod
+++ b/lib/Slang/Date.rakumod
@@ -1,31 +1,36 @@
-use nqp;
-use QAST:from<NQP>;
-
-sub EXPORT(|) {
-
-    role DateLiteral::Grammar {
-        # Patch the <value> rule to add a date literal type.
-        token value:sym<date> {
-            [ \d ** 4 ] '-' [ \d ** 2 ] '-' [ \d ** 2 ]
-        }
+my role Grammar {
+    # Patch the <value> rule to add a date literal type.
+    token value:sym<date> {
+        [ \d ** 4 ] '-' [ \d ** 2 ] '-' [ \d ** 2 ]
     }
+}
 
-    role DateLiteral::Actions {
-        method value:sym<date>(Mu $/) {
-            CATCH { OUTER::<$/>.panic: .message }
+my role Actions {
+    method value:sym<date>(Mu $/) {
+        CATCH { OUTER::<$/>.panic: .message }
+        my $string := $/.Str;
 
-            my $value := $/.Str.Date;
+        # Running under the Raku grammar
+        if self.^name.starts-with('Raku::') {
+            use experimental :rakuast;
+            # XXX fix this when we have anonymous constants in RakuAST
+            # XXX for now codegen as $string.Date
+            make RakuAST::ApplyPostfix.new(
+              operand => RakuAST::StrLiteral.new($string),
+              postfix => RakuAST::Call::Method.new(
+                name => RakuAST::Name.from-identifier("Date")
+              )
+            );
+        }
+
+        # running under legacy grammar
+        else {
+            my $value := $string.Date;
             $*W.add_object_if_no_sc($value);
+            use QAST:from<NQP>;
             make QAST::WVal.new(:$value);
         }
     }
-
-    # Patch the running grammar with our Grammar and Actions roles.
-    $*LANG.define_slang(
-        'MAIN',
-        $*LANG.slang_grammar('MAIN').^mixin(DateLiteral::Grammar),
-        $*LANG.slang_actions('MAIN').^mixin(DateLiteral::Actions),
-    );
-
-   BEGIN Map.new
 }
+
+use Slangify Grammar, Actions


### PR DESCRIPTION
- Slangify removes the internals knowledge needed for activating a slang from the code, and allows any API changes in that area in the future to be handled by a Slangify update, or by removal of the Slangify dependency should Slangify become a core feature.
- RakuAST support is still experimental: for now it codegens as `$string.Date` rather than as a constant